### PR TITLE
Add CRUD operations for bot and news resources

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,7 +35,6 @@ export default antfu({
       case: 'snakeCase',
       ignore: ['README.md'],
     }],
-    'no-use-before-define': 'off',
-    '@typescript-eslint/no-use-before-define': 'error',
+    'no-use-before-define': ['off', { variables: false }],
   },
 });

--- a/src/routes/portfolio/bot/handlers.ts
+++ b/src/routes/portfolio/bot/handlers.ts
@@ -1,0 +1,77 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { eq } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { createToast, DataNotFound, ObjectNotFound } from '@/utils/return';
+
+import type { CreateRoute, GetOneRoute, ListRoute, PatchRoute, RemoveRoute } from './routes';
+
+import { bot } from '../schema';
+
+export const create: AppRouteHandler<CreateRoute> = async (c: any) => {
+  const value = c.req.valid('json');
+
+  const [data] = await db.insert(bot).values(value).returning({
+    name: bot.user_uuid,
+  });
+
+  return c.json(createToast('create', data.name), HSCode.OK);
+};
+
+export const patch: AppRouteHandler<PatchRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+  const updates = c.req.valid('json');
+
+  if (Object.keys(updates).length === 0)
+    return ObjectNotFound(c);
+
+  const [data] = await db.update(bot)
+    .set(updates)
+    .where(eq(bot.uuid, uuid))
+    .returning({
+      name: bot.user_uuid,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('update', data.name), HSCode.OK);
+};
+
+export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.delete(bot)
+    .where(eq(bot.uuid, uuid))
+    .returning({
+      name: bot.user_uuid,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('delete', data.name), HSCode.OK);
+};
+
+export const list: AppRouteHandler<ListRoute> = async (c: any) => {
+  const data = await db.query.bot.findMany();
+
+  return c.json(data || [], HSCode.OK);
+};
+
+export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const data = await db.query.bot.findFirst({
+    where(fields, operators) {
+      return operators.eq(fields.uuid, uuid);
+    },
+  });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(data || {}, HSCode.OK);
+};

--- a/src/routes/portfolio/bot/index.ts
+++ b/src/routes/portfolio/bot/index.ts
@@ -1,0 +1,13 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.list, handlers.list)
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.getOne, handlers.getOne)
+  .openapi(routes.patch, handlers.patch)
+  .openapi(routes.remove, handlers.remove);
+
+export default router;

--- a/src/routes/portfolio/bot/routes.ts
+++ b/src/routes/portfolio/bot/routes.ts
@@ -1,0 +1,124 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent, jsonContentRequired } from 'stoker/openapi/helpers';
+import { createErrorSchema } from 'stoker/openapi/schemas';
+
+import { notFoundSchema } from '@/lib/constants';
+import * as param from '@/lib/param';
+import { createRoute, z } from '@hono/zod-openapi';
+
+import { insertSchema, patchSchema, selectSchema } from './utils';
+
+const tags = ['portfolio.bot'];
+
+export const list = createRoute({
+  path: '/portfolio/bot',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.array(selectSchema),
+      'The list of bot',
+    ),
+  },
+});
+
+export const create = createRoute({
+  path: '/portfolio/bot',
+  method: 'post',
+  request: {
+    body: jsonContentRequired(
+      insertSchema,
+      'The bot to create',
+    ),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The created bot',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(insertSchema),
+      'The validation error(s)',
+    ),
+  },
+});
+
+export const getOne = createRoute({
+  path: '/portfolio/bot/{uuid}',
+  method: 'get',
+  request: {
+    params: param.uuid,
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The requested bot',
+    ),
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'Bot not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(param.uuid),
+      'Invalid id error',
+    ),
+  },
+});
+
+export const patch = createRoute({
+  path: '/portfolio/bot/{uuid}',
+  method: 'patch',
+  request: {
+    params: param.uuid,
+    body: jsonContentRequired(
+      patchSchema,
+      'The bot updates',
+    ),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The updated bot',
+    ),
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'Bot not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(patchSchema)
+        .or(createErrorSchema(param.uuid)),
+      'The validation error(s)',
+    ),
+  },
+});
+
+export const remove = createRoute({
+  path: '/portfolio/bot/{uuid}',
+  method: 'delete',
+  request: {
+    params: param.uuid,
+  },
+  tags,
+  responses: {
+    [HSCode.NO_CONTENT]: {
+      description: 'Bot deleted',
+    },
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'Bot not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(param.uuid),
+      'Invalid id error',
+    ),
+  },
+});
+
+export type ListRoute = typeof list;
+export type CreateRoute = typeof create;
+export type GetOneRoute = typeof getOne;
+export type PatchRoute = typeof patch;
+export type RemoveRoute = typeof remove;

--- a/src/routes/portfolio/bot/utils.ts
+++ b/src/routes/portfolio/bot/utils.ts
@@ -1,0 +1,36 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+
+import { dateTimePattern } from '@/utils';
+
+import { bot } from '../schema';
+
+//* crud
+export const selectSchema = createSelectSchema(bot);
+
+export const insertSchema = createInsertSchema(
+  bot,
+  {
+    uuid: schema => schema.uuid.length(21),
+    user_uuid: schema => schema.user_uuid.length(21),
+
+    created_by: schema => schema.created_by.length(21),
+    created_at: schema => schema.created_at.regex(dateTimePattern, {
+      message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    updated_at: schema => schema.updated_at.regex(dateTimePattern, {
+      message: 'updated_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+  },
+).required({
+  uuid: true,
+  user_uuid: true,
+  category: true,
+  created_at: true,
+  created_by: true,
+}).omit({
+  id: true,
+  updated_at: true,
+  remarks: true,
+});
+
+export const patchSchema = insertSchema.partial();

--- a/src/routes/portfolio/index.ts
+++ b/src/routes/portfolio/index.ts
@@ -1,5 +1,7 @@
 import authorities from './authorities';
 import bot from './bot';
 import info from './info';
+import news from './news';
+import news_entry from './news-entry';
 
-export default [authorities, info, bot];
+export default [authorities, info, bot, news, news_entry];

--- a/src/routes/portfolio/index.ts
+++ b/src/routes/portfolio/index.ts
@@ -1,4 +1,5 @@
 import authorities from './authorities';
+import bot from './bot';
 import info from './info';
 
-export default [authorities, info];
+export default [authorities, info, bot];

--- a/src/routes/portfolio/news-entry/handlers.ts
+++ b/src/routes/portfolio/news-entry/handlers.ts
@@ -1,0 +1,77 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { eq } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { createToast, DataNotFound, ObjectNotFound } from '@/utils/return';
+
+import type { CreateRoute, GetOneRoute, ListRoute, PatchRoute, RemoveRoute } from './routes';
+
+import { news_entry } from '../schema';
+
+export const create: AppRouteHandler<CreateRoute> = async (c: any) => {
+  const value = c.req.valid('json');
+
+  const [data] = await db.insert(news_entry).values(value).returning({
+    name: news_entry.uuid,
+  });
+
+  return c.json(createToast('create', data.name ?? ''), HSCode.OK);
+};
+
+export const patch: AppRouteHandler<PatchRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+  const updates = c.req.valid('json');
+
+  if (Object.keys(updates).length === 0)
+    return ObjectNotFound(c);
+
+  const [data] = await db.update(news_entry)
+    .set(updates)
+    .where(eq(news_entry.uuid, uuid))
+    .returning({
+      name: news_entry.uuid,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('update', data.name ?? ''), HSCode.OK);
+};
+
+export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.delete(news_entry)
+    .where(eq(news_entry.uuid, uuid))
+    .returning({
+      name: news_entry.uuid,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('delete', data.name ?? ''), HSCode.OK);
+};
+
+export const list: AppRouteHandler<ListRoute> = async (c: any) => {
+  const data = await db.query.news_entry.findMany();
+
+  return c.json(data || [], HSCode.OK);
+};
+
+export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const data = await db.query.news_entry.findFirst({
+    where(fields, operators) {
+      return operators.eq(fields.uuid, uuid);
+    },
+  });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(data || {}, HSCode.OK);
+};

--- a/src/routes/portfolio/news-entry/index.ts
+++ b/src/routes/portfolio/news-entry/index.ts
@@ -1,0 +1,13 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.list, handlers.list)
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.getOne, handlers.getOne)
+  .openapi(routes.patch, handlers.patch)
+  .openapi(routes.remove, handlers.remove);
+
+export default router;

--- a/src/routes/portfolio/news-entry/routes.ts
+++ b/src/routes/portfolio/news-entry/routes.ts
@@ -1,0 +1,124 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent, jsonContentRequired } from 'stoker/openapi/helpers';
+import { createErrorSchema } from 'stoker/openapi/schemas';
+
+import { notFoundSchema } from '@/lib/constants';
+import * as param from '@/lib/param';
+import { createRoute, z } from '@hono/zod-openapi';
+
+import { insertSchema, patchSchema, selectSchema } from './utils';
+
+const tags = ['portfolio.news_entry'];
+
+export const list = createRoute({
+  path: '/portfolio/news-entry',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.array(selectSchema),
+      'The list of news-entry',
+    ),
+  },
+});
+
+export const create = createRoute({
+  path: '/portfolio/news-entry',
+  method: 'post',
+  request: {
+    body: jsonContentRequired(
+      insertSchema,
+      'The news-entry to create',
+    ),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The created news-entry',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(insertSchema),
+      'The validation error(s)',
+    ),
+  },
+});
+
+export const getOne = createRoute({
+  path: '/portfolio/news-entry/{uuid}',
+  method: 'get',
+  request: {
+    params: param.uuid,
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The requested news-entry',
+    ),
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'news-entry not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(param.uuid),
+      'Invalid id error',
+    ),
+  },
+});
+
+export const patch = createRoute({
+  path: '/portfolio/news-entry/{uuid}',
+  method: 'patch',
+  request: {
+    params: param.uuid,
+    body: jsonContentRequired(
+      patchSchema,
+      'The news-entry updates',
+    ),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The updated news-entry',
+    ),
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'news-entry not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(patchSchema)
+        .or(createErrorSchema(param.uuid)),
+      'The validation error(s)',
+    ),
+  },
+});
+
+export const remove = createRoute({
+  path: '/portfolio/news-entry/{uuid}',
+  method: 'delete',
+  request: {
+    params: param.uuid,
+  },
+  tags,
+  responses: {
+    [HSCode.NO_CONTENT]: {
+      description: 'news-entry deleted',
+    },
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'news-entry not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(param.uuid),
+      'Invalid id error',
+    ),
+  },
+});
+
+export type ListRoute = typeof list;
+export type CreateRoute = typeof create;
+export type GetOneRoute = typeof getOne;
+export type PatchRoute = typeof patch;
+export type RemoveRoute = typeof remove;

--- a/src/routes/portfolio/news-entry/utils.ts
+++ b/src/routes/portfolio/news-entry/utils.ts
@@ -1,0 +1,32 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+
+import { dateTimePattern } from '@/utils';
+
+import { news_entry } from '../schema';
+
+//* crud
+export const selectSchema = createSelectSchema(news_entry);
+
+export const insertSchema = createInsertSchema(
+  news_entry,
+  {
+    uuid: schema => schema.uuid.length(21),
+    news_uuid: schema => schema.news_uuid.length(21),
+    documents: schema => schema.documents.min(1),
+    created_at: schema => schema.created_at.regex(dateTimePattern, {
+      message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    updated_at: schema => schema.updated_at.regex(dateTimePattern, {
+      message: 'updated_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+  },
+).required({
+  uuid: true,
+  news_uuid: true,
+  documents: true,
+  created_at: true,
+}).omit({
+  updated_at: true,
+});
+
+export const patchSchema = insertSchema.partial();

--- a/src/routes/portfolio/news/handlers.ts
+++ b/src/routes/portfolio/news/handlers.ts
@@ -1,0 +1,77 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { eq } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { createToast, DataNotFound, ObjectNotFound } from '@/utils/return';
+
+import type { CreateRoute, GetOneRoute, ListRoute, PatchRoute, RemoveRoute } from './routes';
+
+import { news } from '../schema';
+
+export const create: AppRouteHandler<CreateRoute> = async (c: any) => {
+  const value = c.req.valid('json');
+
+  const [data] = await db.insert(news).values(value).returning({
+    name: news.created_by,
+  });
+
+  return c.json(createToast('create', data.name ?? ''), HSCode.OK);
+};
+
+export const patch: AppRouteHandler<PatchRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+  const updates = c.req.valid('json');
+
+  if (Object.keys(updates).length === 0)
+    return ObjectNotFound(c);
+
+  const [data] = await db.update(news)
+    .set(updates)
+    .where(eq(news.uuid, uuid))
+    .returning({
+      name: news.created_by,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('update', data.name ?? ''), HSCode.OK);
+};
+
+export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.delete(news)
+    .where(eq(news.uuid, uuid))
+    .returning({
+      name: news.created_by,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('delete', data.name ?? ''), HSCode.OK);
+};
+
+export const list: AppRouteHandler<ListRoute> = async (c: any) => {
+  const data = await db.query.news.findMany();
+
+  return c.json(data || [], HSCode.OK);
+};
+
+export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const data = await db.query.news.findFirst({
+    where(fields, operators) {
+      return operators.eq(fields.uuid, uuid);
+    },
+  });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(data || {}, HSCode.OK);
+};

--- a/src/routes/portfolio/news/index.ts
+++ b/src/routes/portfolio/news/index.ts
@@ -1,0 +1,13 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.list, handlers.list)
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.getOne, handlers.getOne)
+  .openapi(routes.patch, handlers.patch)
+  .openapi(routes.remove, handlers.remove);
+
+export default router;

--- a/src/routes/portfolio/news/routes.ts
+++ b/src/routes/portfolio/news/routes.ts
@@ -1,0 +1,124 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent, jsonContentRequired } from 'stoker/openapi/helpers';
+import { createErrorSchema } from 'stoker/openapi/schemas';
+
+import { notFoundSchema } from '@/lib/constants';
+import * as param from '@/lib/param';
+import { createRoute, z } from '@hono/zod-openapi';
+
+import { insertSchema, patchSchema, selectSchema } from './utils';
+
+const tags = ['portfolio.news'];
+
+export const list = createRoute({
+  path: '/portfolio/news',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.array(selectSchema),
+      'The list of news',
+    ),
+  },
+});
+
+export const create = createRoute({
+  path: '/portfolio/news',
+  method: 'post',
+  request: {
+    body: jsonContentRequired(
+      insertSchema,
+      'The news to create',
+    ),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The created news',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(insertSchema),
+      'The validation error(s)',
+    ),
+  },
+});
+
+export const getOne = createRoute({
+  path: '/portfolio/news/{uuid}',
+  method: 'get',
+  request: {
+    params: param.uuid,
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The requested news',
+    ),
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'news not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(param.uuid),
+      'Invalid id error',
+    ),
+  },
+});
+
+export const patch = createRoute({
+  path: '/portfolio/news/{uuid}',
+  method: 'patch',
+  request: {
+    params: param.uuid,
+    body: jsonContentRequired(
+      patchSchema,
+      'The news updates',
+    ),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The updated news',
+    ),
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'news not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(patchSchema)
+        .or(createErrorSchema(param.uuid)),
+      'The validation error(s)',
+    ),
+  },
+});
+
+export const remove = createRoute({
+  path: '/portfolio/news/{uuid}',
+  method: 'delete',
+  request: {
+    params: param.uuid,
+  },
+  tags,
+  responses: {
+    [HSCode.NO_CONTENT]: {
+      description: 'news deleted',
+    },
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'news not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(param.uuid),
+      'Invalid id error',
+    ),
+  },
+});
+
+export type ListRoute = typeof list;
+export type CreateRoute = typeof create;
+export type GetOneRoute = typeof getOne;
+export type PatchRoute = typeof patch;
+export type RemoveRoute = typeof remove;

--- a/src/routes/portfolio/news/utils.ts
+++ b/src/routes/portfolio/news/utils.ts
@@ -1,0 +1,39 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+
+import { dateTimePattern } from '@/utils';
+
+import { news } from '../schema';
+
+//* crud
+export const selectSchema = createSelectSchema(news);
+
+export const insertSchema = createInsertSchema(
+  news,
+  {
+    uuid: schema => schema.uuid.length(21),
+    title: schema => schema.title.min(1),
+    subtitle: schema => schema.subtitle.min(1),
+    created_by: schema => schema.created_by.length(21),
+    created_at: schema => schema.created_at.regex(dateTimePattern, {
+      message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    updated_at: schema => schema.updated_at.regex(dateTimePattern, {
+      message: 'updated_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+  },
+).required({
+  uuid: true,
+  title: true,
+  subtitle: true,
+  created_at: true,
+  created_by: true,
+}).omit({
+  id: true,
+  description: true,
+  content: true,
+  cover_image: true,
+  updated_at: true,
+  remarks: true,
+});
+
+export const patchSchema = insertSchema.partial();

--- a/src/routes/portfolio/schema.ts
+++ b/src/routes/portfolio/schema.ts
@@ -72,6 +72,41 @@ export const info = portfolio.table('info', {
   remarks: text('remarks'),
 });
 
+//* Bot
+export const bot_category = portfolio.enum('bot_category', [
+  'syndicate',
+  'academic_council',
+]);
+
+export const bot_status = portfolio.enum('bot_status', [
+  'chairman',
+  'member',
+  'member_secretary',
+]);
+
+export const bot_id = portfolio.sequence(
+  'bot_id',
+  {
+    startWith: 1,
+    increment: 1,
+  },
+);
+
+export const bot = portfolio.table('bot', {
+  id: integer('id').default(sql`nextval('portfolio.bot_id')`),
+  uuid: uuid_primary,
+  category: bot_category('category').notNull(),
+  user_uuid: defaultUUID('user_uuid').notNull().references(() => users.uuid, DEFAULT_OPERATION),
+  status: bot_status('status').notNull(),
+  file: text('file').notNull(),
+  description: text('description').notNull(),
+
+  created_at: DateTime('created_at').notNull(),
+  updated_at: DateTime('updated_at'),
+  created_by: defaultUUID('created_by').references(() => users.uuid, DEFAULT_OPERATION),
+  remarks: text('remarks'),
+});
+
 //* relations
 export const portfolio_authorities_rel = relations(authorities, ({ one }) => ({
   user: one(users, {

--- a/src/routes/portfolio/schema.ts
+++ b/src/routes/portfolio/schema.ts
@@ -2,7 +2,7 @@ import { relations, sql } from 'drizzle-orm';
 import { integer, pgSchema, text } from 'drizzle-orm/pg-core';
 
 import { DateTime, defaultUUID, uuid_primary } from '@/lib/variables';
-import { DEFAULT_OPERATION } from '@/utils/db';
+import { DEFAULT_OPERATION, DEFAULT_SEQUENCE } from '@/utils/db';
 
 import { users } from '../hr/schema';
 
@@ -106,6 +106,63 @@ export const bot = portfolio.table('bot', {
   created_by: defaultUUID('created_by').references(() => users.uuid, DEFAULT_OPERATION),
   remarks: text('remarks'),
 });
+
+export const portfolio_bot_rel = relations(bot, ({ one }) => ({
+  user: one(users, {
+    fields: [bot.user_uuid],
+    references: [users.uuid],
+  }),
+  created_by: one(users, {
+    fields: [bot.created_by],
+    references: [users.uuid],
+  }),
+}));
+
+// ? News & Entry
+//* News
+export const news_id = portfolio.sequence('news_id', DEFAULT_SEQUENCE);
+
+export const news = portfolio.table('news', {
+  id: integer('id').default(sql`nextval('portfolio.news_id')`),
+  uuid: uuid_primary,
+  title: text('title').notNull(),
+  subtitle: text('subtitle').notNull(),
+  description: text('description').notNull(),
+  content: text('content').notNull(),
+  cover_image: text('cover_image').notNull(),
+  published_date: text('cover_image').notNull(),
+
+  created_at: DateTime('created_at').notNull().$defaultFn(() => 'now()'),
+  updated_at: DateTime('updated_at').$onUpdate(() => 'now()'),
+  created_by: defaultUUID('created_by').references(() => users.uuid, DEFAULT_OPERATION),
+  remarks: text('remarks'),
+});
+
+export const portfolio_news_rel = relations(news, ({ one, many }) => ({
+  // eslint-disable-next-line ts/no-use-before-define
+  documents: many(news_entry),
+  created_by: one(users, {
+    fields: [news.created_by],
+    references: [users.uuid],
+  }),
+}));
+
+//* News Entry
+export const news_entry = portfolio.table('news_entry', {
+  uuid: uuid_primary,
+  news_uuid: defaultUUID('news_uuid').notNull().references(() => news.uuid, DEFAULT_OPERATION),
+  documents: text('documents').notNull(),
+
+  created_at: DateTime('created_at').notNull().$defaultFn(() => 'now()'),
+  updated_at: DateTime('updated_at').$onUpdate(() => 'now()'),
+});
+
+export const portfolio_news_entry_rel = relations(news_entry, ({ one }) => ({
+  news: one(news, {
+    fields: [news_entry.news_uuid],
+    references: [news.uuid],
+  }),
+}));
 
 //* relations
 export const portfolio_authorities_rel = relations(authorities, ({ one }) => ({

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -3,3 +3,8 @@ import type { UpdateDeleteAction } from 'drizzle-orm/pg-core';
 interface Operation { onDelete: UpdateDeleteAction; onUpdate: UpdateDeleteAction }
 
 export const DEFAULT_OPERATION: Operation = { onDelete: 'set null', onUpdate: 'cascade' };
+
+export const DEFAULT_SEQUENCE = {
+  startWith: 1,
+  increment: 1,
+};


### PR DESCRIPTION
Introduce routes and schema for managing 
- bots 
- news entries

# enables full CRUD functionality for both resources.