### PR TITLE
Update bot list handler to include user details from HR schema

### DIFF
--- a/src/routes/portfolio/bot/handlers.ts
+++ b/src/routes/portfolio/bot/handlers.ts
@@ -1,9 +1,10 @@
 import type { AppRouteHandler } from '@/lib/types';
 
-import { eq } from 'drizzle-orm';
+import { desc, eq } from 'drizzle-orm';
 import * as HSCode from 'stoker/http-status-codes';
 
 import db from '@/db';
+import * as hrSchema from '@/routes/hr/schema';
 import { createToast, DataNotFound, ObjectNotFound } from '@/utils/return';
 
 import type { CreateRoute, GetOneRoute, ListRoute, PatchRoute, RemoveRoute } from './routes';
@@ -56,8 +57,21 @@ export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
 };
 
 export const list: AppRouteHandler<ListRoute> = async (c: any) => {
-  const data = await db.query.bot.findMany();
-
+  // const data = await db.query.bot.findMany();
+  const resultPromise = db.select({
+    uuid: bot.uuid,
+    user_uuid: bot.user_uuid,
+    user_name: hrSchema.users.name,
+    user_designation: hrSchema.designation.name,
+    category: bot.category,
+    status: bot.status,
+    file: bot.file,
+    description: bot.description,
+    created_at: bot.created_at,
+    updated_at: bot.updated_at,
+    remarks: bot.remarks,
+  }).from(bot).leftJoin(hrSchema.users, eq(bot.user_uuid, hrSchema.users.uuid)).leftJoin(hrSchema.designation, eq(hrSchema.users.designation_uuid, hrSchema.designation.uuid));
+  const data: any[] = await resultPromise;
   return c.json(data || [], HSCode.OK);
 };
 


### PR DESCRIPTION
Enhance the bot list handler to retrieve and include user details such as name and designation from the HR schema.