### PR TITLE
Update portfolio bot data formatting with static IDs for roles

### DIFF
--- a/src/routes/portfolio/bot/handlers.ts
+++ b/src/routes/portfolio/bot/handlers.ts
@@ -119,17 +119,17 @@ export const list: AppRouteHandler<ListRoute> = async (c: any) => {
     member: [],
   };
 
-  data.forEach((item) => {
+  data.forEach((item, index) => {
     if (item.status === 'chairman') {
       formattedData.chairperson = {
-        id: item.user_uuid,
+        id: '1',
         name: item.user_name,
         designation: item.user_designation,
       };
     }
     else if (item.status === 'member') {
       formattedData.member.push({
-        id: item.user_uuid,
+        id: (index + 2).toString(),
         name: item.user_name,
         designation: item.user_designation,
       });


### PR DESCRIPTION
Refactor the data formatting logic to use static IDs for the chairperson and members instead of dynamic user UUIDs.