### PR TITLE
Add department_uuid reference to news schema

### DIFF
--- a/src/routes/portfolio/schema.ts
+++ b/src/routes/portfolio/schema.ts
@@ -262,7 +262,7 @@ export const news = portfolio.table('news', {
   content: text('content').notNull(),
   cover_image: text('cover_image').notNull(),
   published_date: text('published_date').notNull(),
-
+  department_uuid: defaultUUID('department_uuid').notNull().references(() => department.uuid, DEFAULT_OPERATION),
   created_at: DateTime('created_at').notNull().$defaultFn(() => 'now()'),
   updated_at: DateTime('updated_at').$onUpdate(() => 'now()'),
   created_by: defaultUUID('created_by').references(() => users.uuid, DEFAULT_OPERATION),
@@ -436,6 +436,10 @@ export const club = portfolio.table('club', {
 
 export const portfolio_news_rel = relations(news, ({ one, many }) => ({
 
+  department: one(department, {
+    fields: [news.department_uuid],
+    references: [department.uuid],
+  }),
   documents: many(news_entry),
   created_by: one(users, {
     fields: [news.created_by],


### PR DESCRIPTION
Introduce a reference to the department in the news schema to establish a relationship between news and department entities.