### PR TITLE
Add department_uuid to info schema and update relations

### DIFF
--- a/src/routes/portfolio/info/utils.ts
+++ b/src/routes/portfolio/info/utils.ts
@@ -12,6 +12,7 @@ export const insertSchema = createInsertSchema(
   {
     uuid: schema => schema.uuid.length(21),
     description: schema => schema.description.min(1),
+    department_uuid: schema => schema.department_uuid.length(21),
     created_by: schema => schema.created_by.length(21),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
@@ -23,12 +24,14 @@ export const insertSchema = createInsertSchema(
 ).required({
   uuid: true,
   description: true,
+  department_uuid: true,
   page_name: true,
   file: true,
   created_at: true,
   created_by: true,
 }).omit({
   id: true,
+  is_global: true,
   updated_at: true,
   remarks: true,
 });

--- a/src/routes/portfolio/schema.ts
+++ b/src/routes/portfolio/schema.ts
@@ -39,32 +39,6 @@ export const authorities = portfolio.table('authorities', {
   remarks: text('remarks'),
 });
 
-//* Info
-export const info_page_name = portfolio.enum('info_page_name', [
-  'notices',
-  'academic_calendar',
-  'examination_guidelines',
-  'information_about_provisional_certificate',
-  'clubs_and_society',
-]);
-
-export const info_id = portfolio.sequence('info_id', DEFAULT_SEQUENCE);
-
-export const info = portfolio.table('info', {
-  id: integer('id').default(sql`nextval('portfolio.info_id')`),
-  uuid: uuid_primary,
-  description: text('description').notNull(),
-  page_name: info_page_name('page_name').notNull(),
-  file: text('file').notNull(),
-  created_at: DateTime('created_at').notNull(),
-  updated_at: DateTime('updated_at'),
-  created_by: defaultUUID('created_by').references(
-    () => users.uuid,
-    DEFAULT_OPERATION,
-  ),
-  remarks: text('remarks'),
-});
-
 //* Bot
 export const bot_category = portfolio.enum('bot_category', [
   'syndicate',
@@ -238,17 +212,6 @@ export const online_admission = portfolio.table('online_admission', {
   remarks: text('remarks'),
 });
 
-export const portfolio_bot_rel = relations(bot, ({ one }) => ({
-  user: one(users, {
-    fields: [bot.user_uuid],
-    references: [users.uuid],
-  }),
-  created_by: one(users, {
-    fields: [bot.created_by],
-    references: [users.uuid],
-  }),
-}));
-
 //* faculty
 
 export const faculty_id = portfolio.sequence(
@@ -313,6 +276,37 @@ export const department = portfolio.table('department', {
   remarks: text('remarks'),
 });
 
+//* Info
+export const info_page_name = portfolio.enum('info_page_name', [
+  'notices',
+  'academic_calendar',
+  'examination_guidelines',
+  'information_about_provisional_certificate',
+  'clubs_and_society',
+]);
+
+export const info_id = portfolio.sequence('info_id', DEFAULT_SEQUENCE);
+
+export const info = portfolio.table('info', {
+  id: integer('id').default(sql`nextval('portfolio.info_id')`),
+  uuid: uuid_primary,
+  department_uuid: defaultUUID('department_uuid').notNull().references(
+    () => department.uuid,
+    DEFAULT_OPERATION,
+  ),
+  description: text('description').notNull(),
+  page_name: info_page_name('page_name').notNull(),
+  file: text('file').notNull(),
+  is_global: boolean('is_global').default(false),
+  created_at: DateTime('created_at').notNull(),
+  updated_at: DateTime('updated_at'),
+  created_by: defaultUUID('created_by').references(
+    () => users.uuid,
+    DEFAULT_OPERATION,
+  ),
+  remarks: text('remarks'),
+});
+
 // * department teachers
 
 export const department_teachers_id = portfolio.sequence(
@@ -333,21 +327,6 @@ export const department_teachers = portfolio.table('department_teachers', {
   created_by: defaultUUID('created_by').references(() => users.uuid, DEFAULT_OPERATION),
   remarks: text('remarks'),
 });
-
-export const portfolio_department_teachers_rel = relations(department_teachers, ({ one }) => ({
-  department: one(department, {
-    fields: [department_teachers.department_uuid],
-    references: [department.uuid],
-  }),
-  teacher: one(users, {
-    fields: [department_teachers.teacher_uuid],
-    references: [users.uuid],
-  }),
-  created_by: one(users, {
-    fields: [department_teachers.created_by],
-    references: [users.uuid],
-  }),
-}));
 
 //* routine
 
@@ -629,4 +608,40 @@ export const portfolio_club_rel = relations(club, ({ one }) => ({
   }),
 }));
 
+export const portfolio_bot_rel = relations(bot, ({ one }) => ({
+  user: one(users, {
+    fields: [bot.user_uuid],
+    references: [users.uuid],
+  }),
+  created_by: one(users, {
+    fields: [bot.created_by],
+    references: [users.uuid],
+  }),
+}));
+
+export const portfolio_department_teachers_rel = relations(department_teachers, ({ one }) => ({
+  department: one(department, {
+    fields: [department_teachers.department_uuid],
+    references: [department.uuid],
+  }),
+  teacher: one(users, {
+    fields: [department_teachers.teacher_uuid],
+    references: [users.uuid],
+  }),
+  created_by: one(users, {
+    fields: [department_teachers.created_by],
+    references: [users.uuid],
+  }),
+}));
+
+export const portfolio_info_rel = relations(info, ({ one }) => ({
+  department: one(department, {
+    fields: [info.department_uuid],
+    references: [department.uuid],
+  }),
+  created_by: one(users, {
+    fields: [info.created_by],
+    references: [users.uuid],
+  }),
+}));
 export default portfolio;


### PR DESCRIPTION
Introduce department_uuid to the info schema and establish necessary relationships with the department table. This enhances data integrity and allows for better organization of information related to departments.