### PR TITLE
Return the first item from data in getOne handler

### DIFF
--- a/src/routes/portfolio/department/handlers.ts
+++ b/src/routes/portfolio/department/handlers.ts
@@ -103,5 +103,5 @@ export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
   if (!data)
     return DataNotFound(c);
 
-  return c.json(data || {}, HSCode.OK);
+  return c.json(data[0] || {}, HSCode.OK);
 };


### PR DESCRIPTION
Update the `getOne` handler to return the first item from the data array instead of the entire array.