### PR TITLE
Include category field in department list response

### DIFF
--- a/src/routes/portfolio/department/handlers.ts
+++ b/src/routes/portfolio/department/handlers.ts
@@ -63,6 +63,7 @@ export const list: AppRouteHandler<ListRoute> = async (c: any) => {
       name: department.name,
       faculty_uuid: department.faculty_uuid,
       faculty_name: faculty.name,
+      category: department.category,
       created_at: department.created_at,
       updated_at: department.updated_at,
       created_by: department.created_by,


### PR DESCRIPTION
Add the category field to the department list response to provide more detailed information about each department.