### PR TITLE
Add is_admin query parameter for data filtering in list handler

### DIFF
--- a/src/routes/portfolio/bot/handlers.ts
+++ b/src/routes/portfolio/bot/handlers.ts
@@ -60,7 +60,7 @@ export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
 };
 
 export const list: AppRouteHandler<ListRoute> = async (c: any) => {
-  const { category } = c.req.valid('query');
+  const { category, is_admin } = c.req.valid('query');
 
   // const data = await db.query.bot.findMany();
   const resultPromise = db.select({
@@ -88,40 +88,6 @@ export const list: AppRouteHandler<ListRoute> = async (c: any) => {
   }
 
   const data: any[] = await resultPromise;
-
-  // const formattedData = data.map((item) => {
-  //   const formattedItem: any = {
-  //     uuid: item.uuid,
-  //     user_uuid: item.user_uuid,
-  //     user_name: item.user_name,
-  //     user_designation: item.user_designation,
-  //     category: item.category,
-  //     status: item.status,
-  //     file: item.file,
-  //     description: item.description,
-  //     created_at: item.created_at,
-  //     updated_at: item.updated_at,
-  //     remarks: item.remarks,
-  //   };
-
-  //   if (item.status === 'chairman') {
-  //     formattedItem.chairperson = {
-  //       id: item.user_uuid,
-  //       name: item.user_name,
-  //       designation: item.user_designation,
-  //     };
-  //   }
-  //   else if (item.status === 'member') {
-  //     formattedItem.member = formattedItem.member || [];
-  //     formattedItem.member.push({
-  //       id: item.user_uuid,
-  //       name: item.user_name,
-  //       designation: item.user_designation,
-  //     });
-  //   }
-
-  //   return formattedItem;
-  // });
   interface Person {
     id: string;
     name: string;
@@ -150,7 +116,15 @@ export const list: AppRouteHandler<ListRoute> = async (c: any) => {
     }
   });
 
-  return c.json(formattedData, HSCode.OK);
+  let filterData;
+  if (is_admin === 'true') {
+    filterData = data;
+  }
+  else {
+    filterData = formattedData;
+  }
+
+  return c.json(filterData, HSCode.OK);
 };
 
 export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {

--- a/src/routes/portfolio/bot/routes.ts
+++ b/src/routes/portfolio/bot/routes.ts
@@ -17,6 +17,7 @@ export const list = createRoute({
   request: {
     query: z.object({
       category: z.string().optional(),
+      is_admin: z.string().optional(),
     }),
   },
   responses: {


### PR DESCRIPTION
Introduce an `is_admin` query parameter to the list handler, enabling conditional data filtering based on the user's admin status. This change enhances the flexibility of data retrieval.