### PR TITLE
Add id field to bot selection in portfolio handler

### DIFF
--- a/src/routes/portfolio/bot/handlers.ts
+++ b/src/routes/portfolio/bot/handlers.ts
@@ -64,6 +64,7 @@ export const list: AppRouteHandler<ListRoute> = async (c: any) => {
 
   // const data = await db.query.bot.findMany();
   const resultPromise = db.select({
+    id: bot.id,
     uuid: bot.uuid,
     user_uuid: bot.user_uuid,
     user_name: hrSchema.users.name,


### PR DESCRIPTION
Include the id field in the bot selection query to enhance data retrieval in the portfolio handler.