### PR TITLE
Change office entries order to ascending by creation date

### DIFF
--- a/src/routes/portfolio/office/handlers.ts
+++ b/src/routes/portfolio/office/handlers.ts
@@ -145,7 +145,7 @@ export const getOfficeAndOfficeEntryDetailsByOfficeUuid: AppRouteHandler<GetOffi
     },
     with: {
       office_entries: {
-        orderBy: (office_entries, { desc }) => [desc(office_entries.created_at)],
+        orderBy: (office_entries, { asc }) => [asc(office_entries.created_at)],
       },
     },
 


### PR DESCRIPTION
Modify the order of office entries to be sorted in ascending order based on their creation date.