### PR TITLE
Add is_global field to news schema and update handlers

### DIFF
--- a/src/routes/portfolio/news/handlers.ts
+++ b/src/routes/portfolio/news/handlers.ts
@@ -133,6 +133,7 @@ export const list: AppRouteHandler<ListRoute> = async (c: any) => {
     published_date: news.published_date,
     remarks: news.remarks,
     carousel: sql`ARRAY(SELECT json_build_object('value', uuid, 'label', documents) FROM portfolio.news_entry WHERE news_uuid = portfolio.news.uuid)`,
+    is_global: news.is_global,
   })
     .from(news)
     .leftJoin(department, eq(news.department_uuid, department.uuid));
@@ -202,6 +203,7 @@ export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
     published_date: news.published_date,
     remarks: news.remarks,
     carousel: sql`ARRAY(SELECT json_build_object('value', uuid, 'label', documents) FROM portfolio.news_entry WHERE news_uuid = portfolio.news.uuid)`,
+    is_global: news.is_global,
   })
     .from(news)
     .leftJoin(department, eq(news.department_uuid, department.uuid))
@@ -232,6 +234,7 @@ export async function getNewsAndNewsEntryDetailsByNewsUuid(c: any) {
     published_date: news.published_date,
     remarks: news.remarks,
     entry: sql`ARRAY(SELECT json_build_object('uuid', uuid, 'documents', documents,'created_at', created_at, 'updated_at',updated_at) FROM portfolio.news_entry WHERE news_uuid = portfolio.news.uuid)`,
+    is_global: news.is_global,
   })
     .from(news)
     .leftJoin(department, eq(news.department_uuid, department.uuid))
@@ -269,6 +272,7 @@ export const getLatestNews: AppRouteHandler<GetLatestNewsRoute> = async (c: any)
     cover_image: news.cover_image,
     published_date: news.published_date,
     remarks: news.remarks,
+    is_global: news.is_global,
   })
     .from(news)
     .leftJoin(department, eq(news.department_uuid, department.uuid))

--- a/src/routes/portfolio/news/utils.ts
+++ b/src/routes/portfolio/news/utils.ts
@@ -37,6 +37,7 @@ export const insertSchema = createInsertSchema(
   description: true,
   updated_at: true,
   remarks: true,
+  is_global: true,
 }).omit({
   id: true,
 });

--- a/src/routes/portfolio/schema.ts
+++ b/src/routes/portfolio/schema.ts
@@ -489,6 +489,7 @@ export const news = portfolio.table('news', {
   updated_at: DateTime('updated_at').$onUpdate(() => 'now()'),
   created_by: defaultUUID('created_by').references(() => users.uuid, DEFAULT_OPERATION),
   remarks: text('remarks'),
+  is_global: boolean('is_global').default(false),
 });
 
 //* News Entry


### PR DESCRIPTION
Introduce an `is_global` field in the news schema and update related handlers to accommodate this new field.