### PR TITLE
Add is_global field to news creation handler

### DIFF
--- a/src/routes/portfolio/news/handlers.ts
+++ b/src/routes/portfolio/news/handlers.ts
@@ -34,6 +34,7 @@ export const create: AppRouteHandler<CreateRoute> = async (c: any) => {
     remarks: formData.remarks,
     cover_image: coverImagePath,
     published_date: formData.published_date,
+    is_global: formData.is_global,
   };
 
   const [data] = await db.insert(news).values(value).returning({


### PR DESCRIPTION
Introduce an `is_global` field in the news creation handler to allow for global news items.