### PR TITLE
Add is_global query parameter to news list handler and route

### DIFF
--- a/src/routes/portfolio/news/handlers.ts
+++ b/src/routes/portfolio/news/handlers.ts
@@ -113,7 +113,7 @@ export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
 
 export const list: AppRouteHandler<ListRoute> = async (c: any) => {
   // const data = await db.query.news.findMany();
-  const { department_name, latest, is_pagination, access } = c.req.valid('query');
+  const { department_name, latest, is_pagination, access, is_global } = c.req.valid('query');
 
   let accessArray = [];
   if (access) {
@@ -157,6 +157,9 @@ export const list: AppRouteHandler<ListRoute> = async (c: any) => {
     if (accessArray.length > 0) {
       baseQuery.having(inArray(department.short_name, accessArray));
     }
+  }
+  if (is_global === 'true') {
+    baseQuery.where(eq(news.is_global, true));
   }
 
   const data = await baseQuery;

--- a/src/routes/portfolio/news/routes.ts
+++ b/src/routes/portfolio/news/routes.ts
@@ -31,6 +31,7 @@ export const list = createRoute({
       orderby: z.string().optional(),
       is_pagination: z.string().optional(),
       access: z.string().optional(),
+      is_global: z.string().optional(),
     }),
   },
 });


### PR DESCRIPTION
Introduce an `is_global` query parameter to filter news items based on their global status in the news list handler.