### PR TITLE
Update news list query to group by UUID and filter by is_global

### DIFF
--- a/src/routes/portfolio/news/handlers.ts
+++ b/src/routes/portfolio/news/handlers.ts
@@ -159,7 +159,8 @@ export const list: AppRouteHandler<ListRoute> = async (c: any) => {
     }
   }
   if (is_global === 'true') {
-    baseQuery.where(eq(news.is_global, true));
+    baseQuery.groupBy(news.uuid, news.is_global, department.name);
+    baseQuery.having(eq(news.is_global, true));
   }
 
   const data = await baseQuery;


### PR DESCRIPTION
Refactor the news list query to group results by UUID and apply a filter for global news items.