### PR TITLE
Fix user UUID field in patchCanAccess handler

### DIFF
--- a/src/routes/hr/auth_user/handlers.ts
+++ b/src/routes/hr/auth_user/handlers.ts
@@ -229,7 +229,7 @@ export const patchCanAccess: AppRouteHandler<PatchCanAccessRoute> = async (c: an
 
   const [data] = await db.update(auth_user)
     .set({ can_access })
-    .where(eq(auth_user.user_uuid, uuid))
+    .where(eq(auth_user.uuid, uuid))
     .returning({
       name: auth_user.uuid,
     });


### PR DESCRIPTION
Correct the reference to the user UUID field in the patchCanAccess handler to ensure proper functionality.