### PR TITLE
Fix user UUID field in access query handler

### DIFF
--- a/src/routes/hr/auth_user/handlers.ts
+++ b/src/routes/hr/auth_user/handlers.ts
@@ -213,7 +213,7 @@ export const getCanAccess: AppRouteHandler<GetCanAccessRoute> = async (c: any) =
   })
     .from(auth_user)
     .leftJoin(users, eq(auth_user.user_uuid, users.uuid))
-    .where(eq(users.uuid, uuid));
+    .where(eq(auth_user.uuid, uuid));
 
   const [data] = await resultPromise;
 


### PR DESCRIPTION
Update the query in the `getCanAccess` handler to use the correct user UUID field for accurate access checks.