### PR TITLE
feat(fde): add evaluation and related routes, handlers, and schemas

### DIFF
--- a/src/routes/fde/evaluation/handlers.ts
+++ b/src/routes/fde/evaluation/handlers.ts
@@ -1,0 +1,106 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { eq } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { users } from '@/routes/hr/schema';
+import { createToast, DataNotFound, ObjectNotFound } from '@/utils/return';
+
+import type { CreateRoute, GetOneRoute, ListRoute, PatchRoute, RemoveRoute } from './routes';
+
+import { evaluation, qns } from '../schema';
+
+export const create: AppRouteHandler<CreateRoute> = async (c: any) => {
+  const value = c.req.valid('json');
+
+  const [data] = await db.insert(evaluation).values(value).returning({
+    name: evaluation.uuid,
+  });
+
+  return c.json(createToast('create', data.name ?? ''), HSCode.OK);
+};
+
+export const patch: AppRouteHandler<PatchRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+  const updates = c.req.valid('json');
+
+  if (Object.keys(updates).length === 0)
+    return ObjectNotFound(c);
+
+  const [data] = await db.update(evaluation)
+    .set(updates)
+    .where(eq(evaluation.uuid, uuid))
+    .returning({
+      name: evaluation.uuid,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('update', data.name ?? ''), HSCode.OK);
+};
+
+export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.delete(evaluation)
+    .where(eq(evaluation.uuid, uuid))
+    .returning({
+      name: evaluation.uuid,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('delete', data.name ?? ''), HSCode.OK);
+};
+
+export const list: AppRouteHandler<ListRoute> = async (c: any) => {
+  // const data = await db.query.evaluation.findMany();
+  const resultPromise = db.select({
+    uuid: evaluation.uuid,
+    respond_student_uuid: evaluation.respond_student_uuid,
+    qns_uuid: evaluation.qns_uuid,
+    qns_name: qns.name,
+    rating: evaluation.rating,
+    created_by: evaluation.created_by,
+    created_by_name: users.name,
+    created_at: evaluation.created_at,
+    updated_at: evaluation.updated_at,
+    remarks: evaluation.remarks,
+  })
+    .from(evaluation)
+    .leftJoin(qns, eq(qns.uuid, evaluation.qns_uuid))
+    .leftJoin(users, eq(users.uuid, evaluation.created_by));
+
+  const data = await resultPromise;
+
+  return c.json(data || [], HSCode.OK);
+};
+
+export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.select({
+    uuid: evaluation.uuid,
+    respond_student_uuid: evaluation.respond_student_uuid,
+    qns_uuid: evaluation.qns_uuid,
+    qns_name: qns.name,
+    rating: evaluation.rating,
+    created_by: evaluation.created_by,
+    created_by_name: users.name,
+    created_at: evaluation.created_at,
+    updated_at: evaluation.updated_at,
+    remarks: evaluation.remarks,
+  })
+    .from(evaluation)
+    .leftJoin(qns, eq(qns.uuid, evaluation.qns_uuid))
+    .leftJoin(users, eq(users.uuid, evaluation.created_by))
+    .where(eq(evaluation.uuid, uuid));
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(data, HSCode.OK);
+};

--- a/src/routes/fde/evaluation/index.ts
+++ b/src/routes/fde/evaluation/index.ts
@@ -1,0 +1,13 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.list, handlers.list)
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.getOne, handlers.getOne)
+  .openapi(routes.patch, handlers.patch)
+  .openapi(routes.remove, handlers.remove);
+
+export default router;

--- a/src/routes/fde/evaluation/routes.ts
+++ b/src/routes/fde/evaluation/routes.ts
@@ -1,0 +1,124 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent, jsonContentRequired } from 'stoker/openapi/helpers';
+import { createErrorSchema } from 'stoker/openapi/schemas';
+
+import { notFoundSchema } from '@/lib/constants';
+import * as param from '@/lib/param';
+import { createRoute, z } from '@hono/zod-openapi';
+
+import { insertSchema, patchSchema, selectSchema } from './utils';
+
+const tags = ['fde.evaluation'];
+
+export const list = createRoute({
+  path: '/fde/evaluation',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.array(selectSchema),
+      'The list of evaluation',
+    ),
+  },
+});
+
+export const create = createRoute({
+  path: '/fde/evaluation',
+  method: 'post',
+  request: {
+    body: jsonContentRequired(
+      insertSchema,
+      'The evaluation to create',
+    ),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The created evaluation',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(insertSchema),
+      'The validation error(s)',
+    ),
+  },
+});
+
+export const getOne = createRoute({
+  path: '/fde/evaluation/{uuid}',
+  method: 'get',
+  request: {
+    params: param.uuid,
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The requested evaluation',
+    ),
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'evaluation not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(param.uuid),
+      'Invalid id error',
+    ),
+  },
+});
+
+export const patch = createRoute({
+  path: '/fde/evaluation/{uuid}',
+  method: 'patch',
+  request: {
+    params: param.uuid,
+    body: jsonContentRequired(
+      patchSchema,
+      'The evaluation to update',
+    ),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The updated evaluation',
+    ),
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'evaluation not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(patchSchema)
+        .or(createErrorSchema(param.uuid)),
+      'The validation error(s)',
+    ),
+  },
+});
+
+export const remove = createRoute({
+  path: '/fde/evaluation/{uuid}',
+  method: 'delete',
+  request: {
+    params: param.uuid,
+  },
+  tags,
+  responses: {
+    [HSCode.NO_CONTENT]: {
+      description: 'The evaluation was deleted successfully',
+    },
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'evaluation not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(param.uuid),
+      'Invalid id error',
+    ),
+  },
+});
+
+export type ListRoute = typeof list;
+export type CreateRoute = typeof create;
+export type GetOneRoute = typeof getOne;
+export type PatchRoute = typeof patch;
+export type RemoveRoute = typeof remove;

--- a/src/routes/fde/evaluation/utils.ts
+++ b/src/routes/fde/evaluation/utils.ts
@@ -1,0 +1,36 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+
+import { dateTimePattern } from '@/utils';
+
+import { evaluation } from '../schema';
+
+//* crud
+export const selectSchema = createSelectSchema(evaluation);
+
+export const insertSchema = createInsertSchema(
+  evaluation,
+  {
+    uuid: schema => schema.uuid.length(21),
+    respond_student_uuid: schema => schema.respond_student_uuid.length(21),
+    qns_uuid: schema => schema.qns_uuid.length(21),
+    created_by: schema => schema.created_by.length(21),
+    created_at: schema => schema.created_at.regex(dateTimePattern, {
+      message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    updated_at: schema => schema.updated_at.regex(dateTimePattern, {
+      message: 'updated_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+  },
+).required({
+  uuid: true,
+  respond_student_uuid: true,
+  qns_uuid: true,
+  rating: true,
+  created_at: true,
+  created_by: true,
+}).partial({
+  updated_at: true,
+  remarks: true,
+});
+
+export const patchSchema = insertSchema.partial();

--- a/src/routes/fde/index.ts
+++ b/src/routes/fde/index.ts
@@ -1,0 +1,6 @@
+import evaluation from './evaluation';
+import qns from './qns';
+import qns_category from './qns_category';
+import respond_student from './respond_student';
+
+export default [qns, qns_category, respond_student, evaluation];

--- a/src/routes/fde/qns/handlers.ts
+++ b/src/routes/fde/qns/handlers.ts
@@ -1,0 +1,108 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { eq } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { users } from '@/routes/hr/schema';
+import { createToast, DataNotFound, ObjectNotFound } from '@/utils/return';
+
+import type { CreateRoute, GetOneRoute, ListRoute, PatchRoute, RemoveRoute } from './routes';
+
+import { qns, qns_category } from '../schema';
+
+export const create: AppRouteHandler<CreateRoute> = async (c: any) => {
+  const value = c.req.valid('json');
+
+  const [data] = await db.insert(qns).values(value).returning({
+    name: qns.name,
+  });
+
+  return c.json(createToast('create', data.name ?? ''), HSCode.OK);
+};
+
+export const patch: AppRouteHandler<PatchRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+  const updates = c.req.valid('json');
+
+  if (Object.keys(updates).length === 0)
+    return ObjectNotFound(c);
+
+  const [data] = await db.update(qns)
+    .set(updates)
+    .where(eq(qns.uuid, uuid))
+    .returning({
+      name: qns.name,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('update', data.name ?? ''), HSCode.OK);
+};
+
+export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.delete(qns)
+    .where(eq(qns.uuid, uuid))
+    .returning({
+      name: qns.name,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('delete', data.name ?? ''), HSCode.OK);
+};
+
+export const list: AppRouteHandler<ListRoute> = async (c: any) => {
+  // const data = await db.query.qns.findMany();
+  const resultPromise = db.select({
+    uuid: qns.uuid,
+    qns_category_uuid: qns.qns_category_uuid,
+    qns_category_name: qns_category.name,
+    name: qns.name,
+    index: qns.index,
+    active: qns.active,
+    created_by: qns.created_by,
+    created_by_name: users.name,
+    created_at: qns.created_at,
+    updated_at: qns.updated_at,
+    remarks: qns.remarks,
+  })
+    .from(qns)
+    .leftJoin(qns_category, eq(qns_category.uuid, qns.qns_category_uuid))
+    .leftJoin(users, eq(users.uuid, qns.created_by));
+
+  const data = await resultPromise;
+
+  return c.json(data || [], HSCode.OK);
+};
+
+export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.select({
+    uuid: qns.uuid,
+    qns_category_uuid: qns.qns_category_uuid,
+    qns_category_name: qns_category.name,
+    name: qns.name,
+    index: qns.index,
+    active: qns.active,
+    created_by: qns.created_by,
+    created_by_name: users.name,
+    created_at: qns.created_at,
+    updated_at: qns.updated_at,
+    remarks: qns.remarks,
+  })
+    .from(qns)
+    .leftJoin(qns_category, eq(qns_category.uuid, qns.qns_category_uuid))
+    .leftJoin(users, eq(users.uuid, qns.created_by))
+    .where(eq(qns.uuid, uuid));
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(data, HSCode.OK);
+};

--- a/src/routes/fde/qns/index.ts
+++ b/src/routes/fde/qns/index.ts
@@ -1,0 +1,13 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.list, handlers.list)
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.getOne, handlers.getOne)
+  .openapi(routes.patch, handlers.patch)
+  .openapi(routes.remove, handlers.remove);
+
+export default router;

--- a/src/routes/fde/qns/routes.ts
+++ b/src/routes/fde/qns/routes.ts
@@ -1,0 +1,124 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent, jsonContentRequired } from 'stoker/openapi/helpers';
+import { createErrorSchema } from 'stoker/openapi/schemas';
+
+import { notFoundSchema } from '@/lib/constants';
+import * as param from '@/lib/param';
+import { createRoute, z } from '@hono/zod-openapi';
+
+import { insertSchema, patchSchema, selectSchema } from './utils';
+
+const tags = ['fde.qns'];
+
+export const list = createRoute({
+  path: '/fde/qns',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.array(selectSchema),
+      'The list of qns',
+    ),
+  },
+});
+
+export const create = createRoute({
+  path: '/fde/qns',
+  method: 'post',
+  request: {
+    body: jsonContentRequired(
+      insertSchema,
+      'The qns to create',
+    ),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The created qns',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(insertSchema),
+      'The validation error(s)',
+    ),
+  },
+});
+
+export const getOne = createRoute({
+  path: '/fde/qns/{uuid}',
+  method: 'get',
+  request: {
+    params: param.uuid,
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The requested qns',
+    ),
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'qns not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(param.uuid),
+      'Invalid id error',
+    ),
+  },
+});
+
+export const patch = createRoute({
+  path: '/fde/qns/{uuid}',
+  method: 'patch',
+  request: {
+    params: param.uuid,
+    body: jsonContentRequired(
+      patchSchema,
+      'The qns to update',
+    ),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The updated qns',
+    ),
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'qns not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(patchSchema)
+        .or(createErrorSchema(param.uuid)),
+      'The validation error(s)',
+    ),
+  },
+});
+
+export const remove = createRoute({
+  path: '/fde/qns/{uuid}',
+  method: 'delete',
+  request: {
+    params: param.uuid,
+  },
+  tags,
+  responses: {
+    [HSCode.NO_CONTENT]: {
+      description: 'The qns was deleted successfully',
+    },
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'qns not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(param.uuid),
+      'Invalid id error',
+    ),
+  },
+});
+
+export type ListRoute = typeof list;
+export type CreateRoute = typeof create;
+export type GetOneRoute = typeof getOne;
+export type PatchRoute = typeof patch;
+export type RemoveRoute = typeof remove;

--- a/src/routes/fde/qns/utils.ts
+++ b/src/routes/fde/qns/utils.ts
@@ -1,0 +1,37 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+
+import { dateTimePattern } from '@/utils';
+
+import { qns } from '../schema';
+
+//* crud
+export const selectSchema = createSelectSchema(qns);
+
+export const insertSchema = createInsertSchema(
+  qns,
+  {
+    uuid: schema => schema.uuid.length(21),
+    qns_category_uuid: schema => schema.qns_category_uuid.length(21),
+    name: schema => schema.name.min(1),
+    created_by: schema => schema.created_by.length(21),
+    created_at: schema => schema.created_at.regex(dateTimePattern, {
+      message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    updated_at: schema => schema.updated_at.regex(dateTimePattern, {
+      message: 'updated_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+  },
+).required({
+  uuid: true,
+  name: true,
+  index: true,
+  qns_category_uuid: true,
+  created_at: true,
+  created_by: true,
+}).partial({
+  active: true,
+  updated_at: true,
+  remarks: true,
+});
+
+export const patchSchema = insertSchema.partial();

--- a/src/routes/fde/qns_category/handlers.ts
+++ b/src/routes/fde/qns_category/handlers.ts
@@ -1,0 +1,102 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { eq } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { users } from '@/routes/hr/schema';
+import { createToast, DataNotFound, ObjectNotFound } from '@/utils/return';
+
+import type { CreateRoute, GetOneRoute, ListRoute, PatchRoute, RemoveRoute } from './routes';
+
+import { qns_category } from '../schema';
+
+export const create: AppRouteHandler<CreateRoute> = async (c: any) => {
+  const value = c.req.valid('json');
+
+  const [data] = await db.insert(qns_category).values(value).returning({
+    name: qns_category.name,
+  });
+
+  return c.json(createToast('create', data.name ?? ''), HSCode.OK);
+};
+
+export const patch: AppRouteHandler<PatchRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+  const updates = c.req.valid('json');
+
+  if (Object.keys(updates).length === 0)
+    return ObjectNotFound(c);
+
+  const [data] = await db.update(qns_category)
+    .set(updates)
+    .where(eq(qns_category.uuid, uuid))
+    .returning({
+      name: qns_category.name,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('update', data.name ?? ''), HSCode.OK);
+};
+
+export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.delete(qns_category)
+    .where(eq(qns_category.uuid, uuid))
+    .returning({
+      name: qns_category.name,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('delete', data.name ?? ''), HSCode.OK);
+};
+
+export const list: AppRouteHandler<ListRoute> = async (c: any) => {
+  // const data = await db.query.qns_category.findMany();
+  const resultPromise = db.select({
+    uuid: qns_category.uuid,
+    name: qns_category.name,
+    index: qns_category.index,
+    min_percentage: qns_category.min_percentage,
+    created_by: qns_category.created_by,
+    created_by_name: users.name,
+    created_at: qns_category.created_at,
+    updated_at: qns_category.updated_at,
+    remarks: qns_category.remarks,
+  })
+    .from(qns_category)
+    .leftJoin(users, eq(users.uuid, qns_category.created_by));
+
+  const data = await resultPromise;
+
+  return c.json(data || [], HSCode.OK);
+};
+
+export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.select({
+    uuid: qns_category.uuid,
+    name: qns_category.name,
+    index: qns_category.index,
+    min_percentage: qns_category.min_percentage,
+    created_by: qns_category.created_by,
+    created_by_name: users.name,
+    created_at: qns_category.created_at,
+    updated_at: qns_category.updated_at,
+    remarks: qns_category.remarks,
+  })
+    .from(qns_category)
+    .leftJoin(users, eq(users.uuid, qns_category.created_by))
+    .where(eq(qns_category.uuid, uuid));
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(data, HSCode.OK);
+};

--- a/src/routes/fde/qns_category/index.ts
+++ b/src/routes/fde/qns_category/index.ts
@@ -1,0 +1,13 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.list, handlers.list)
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.getOne, handlers.getOne)
+  .openapi(routes.patch, handlers.patch)
+  .openapi(routes.remove, handlers.remove);
+
+export default router;

--- a/src/routes/fde/qns_category/routes.ts
+++ b/src/routes/fde/qns_category/routes.ts
@@ -1,0 +1,124 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent, jsonContentRequired } from 'stoker/openapi/helpers';
+import { createErrorSchema } from 'stoker/openapi/schemas';
+
+import { notFoundSchema } from '@/lib/constants';
+import * as param from '@/lib/param';
+import { createRoute, z } from '@hono/zod-openapi';
+
+import { insertSchema, patchSchema, selectSchema } from './utils';
+
+const tags = ['fde.qns_category'];
+
+export const list = createRoute({
+  path: '/fde/qns-category',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.array(selectSchema),
+      'The list of qns categories',
+    ),
+  },
+});
+
+export const create = createRoute({
+  path: '/fde/qns-category',
+  method: 'post',
+  request: {
+    body: jsonContentRequired(
+      insertSchema,
+      'The qns category to create',
+    ),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The created qns category',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(insertSchema),
+      'The validation error(s)',
+    ),
+  },
+});
+
+export const getOne = createRoute({
+  path: '/fde/qns-category/{uuid}',
+  method: 'get',
+  request: {
+    params: param.uuid,
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The requested qns category',
+    ),
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'qns category not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(param.uuid),
+      'Invalid id error',
+    ),
+  },
+});
+
+export const patch = createRoute({
+  path: '/fde/qns-category/{uuid}',
+  method: 'patch',
+  request: {
+    params: param.uuid,
+    body: jsonContentRequired(
+      patchSchema,
+      'The qns category to update',
+    ),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The updated qns category',
+    ),
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'qns category not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(patchSchema)
+        .or(createErrorSchema(param.uuid)),
+      'The validation error(s)',
+    ),
+  },
+});
+
+export const remove = createRoute({
+  path: '/fde/qns-category/{uuid}',
+  method: 'delete',
+  request: {
+    params: param.uuid,
+  },
+  tags,
+  responses: {
+    [HSCode.NO_CONTENT]: {
+      description: 'The qns category was deleted successfully',
+    },
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'qns category not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(param.uuid),
+      'Invalid id error',
+    ),
+  },
+});
+
+export type ListRoute = typeof list;
+export type CreateRoute = typeof create;
+export type GetOneRoute = typeof getOne;
+export type PatchRoute = typeof patch;
+export type RemoveRoute = typeof remove;

--- a/src/routes/fde/qns_category/utils.ts
+++ b/src/routes/fde/qns_category/utils.ts
@@ -1,0 +1,35 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+
+import { dateTimePattern } from '@/utils';
+
+import { qns_category } from '../schema';
+
+//* crud
+export const selectSchema = createSelectSchema(qns_category);
+
+export const insertSchema = createInsertSchema(
+  qns_category,
+  {
+    uuid: schema => schema.uuid.length(21),
+    name: schema => schema.name.min(1),
+    created_by: schema => schema.created_by.length(21),
+    created_at: schema => schema.created_at.regex(dateTimePattern, {
+      message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    updated_at: schema => schema.updated_at.regex(dateTimePattern, {
+      message: 'updated_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+  },
+).required({
+  uuid: true,
+  name: true,
+  index: true,
+  min_percentage: true,
+  created_at: true,
+  created_by: true,
+}).partial({
+  updated_at: true,
+  remarks: true,
+});
+
+export const patchSchema = insertSchema.partial();

--- a/src/routes/fde/respond_student/handlers.ts
+++ b/src/routes/fde/respond_student/handlers.ts
@@ -1,0 +1,105 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { eq } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { users } from '@/routes/hr/schema';
+import { sem_crs_thr_entry } from '@/routes/lib/schema';
+import { createToast, DataNotFound, ObjectNotFound } from '@/utils/return';
+
+import type { CreateRoute, GetOneRoute, ListRoute, PatchRoute, RemoveRoute } from './routes';
+
+import { respond_student } from '../schema';
+
+export const create: AppRouteHandler<CreateRoute> = async (c: any) => {
+  const value = c.req.valid('json');
+
+  const [data] = await db.insert(respond_student).values(value).returning({
+    name: respond_student.id,
+  });
+
+  return c.json(createToast('create', data.name ?? ''), HSCode.OK);
+};
+
+export const patch: AppRouteHandler<PatchRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+  const updates = c.req.valid('json');
+
+  if (Object.keys(updates).length === 0)
+    return ObjectNotFound(c);
+
+  const [data] = await db.update(respond_student)
+    .set(updates)
+    .where(eq(respond_student.uuid, uuid))
+    .returning({
+      name: respond_student.id,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('update', data.name ?? ''), HSCode.OK);
+};
+
+export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.delete(respond_student)
+    .where(eq(respond_student.uuid, uuid))
+    .returning({
+      name: respond_student.id,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('delete', data.name ?? ''), HSCode.OK);
+};
+
+export const list: AppRouteHandler<ListRoute> = async (c: any) => {
+  // const data = await db.query.respond_student.findMany();
+  const resultPromise = db.select({
+    uuid: respond_student.uuid,
+    sem_crs_thr_entry_uuid: respond_student.sem_crs_thr_entry_uuid,
+    id: respond_student.id,
+    evaluation_time: respond_student.evaluation_time,
+    created_by: respond_student.created_by,
+    created_by_name: users.name,
+    created_at: respond_student.created_at,
+    updated_at: respond_student.updated_at,
+    remarks: respond_student.remarks,
+  })
+    .from(respond_student)
+    .leftJoin(sem_crs_thr_entry, eq(sem_crs_thr_entry.uuid, respond_student.sem_crs_thr_entry_uuid))
+    .leftJoin(users, eq(users.uuid, respond_student.created_by));
+
+  const data = await resultPromise;
+
+  return c.json(data || [], HSCode.OK);
+};
+
+export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.select({
+    uuid: respond_student.uuid,
+    sem_crs_thr_entry_uuid: respond_student.sem_crs_thr_entry_uuid,
+    id: respond_student.id,
+    evaluation_time: respond_student.evaluation_time,
+    created_by: respond_student.created_by,
+    created_by_name: users.name,
+    created_at: respond_student.created_at,
+    updated_at: respond_student.updated_at,
+    remarks: respond_student.remarks,
+  })
+    .from(respond_student)
+    .leftJoin(sem_crs_thr_entry, eq(sem_crs_thr_entry.uuid, respond_student.sem_crs_thr_entry_uuid))
+    .leftJoin(users, eq(users.uuid, respond_student.created_by))
+    .where(eq(respond_student.uuid, uuid));
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(data, HSCode.OK);
+};

--- a/src/routes/fde/respond_student/index.ts
+++ b/src/routes/fde/respond_student/index.ts
@@ -1,0 +1,13 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.list, handlers.list)
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.getOne, handlers.getOne)
+  .openapi(routes.patch, handlers.patch)
+  .openapi(routes.remove, handlers.remove);
+
+export default router;

--- a/src/routes/fde/respond_student/routes.ts
+++ b/src/routes/fde/respond_student/routes.ts
@@ -1,0 +1,124 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent, jsonContentRequired } from 'stoker/openapi/helpers';
+import { createErrorSchema } from 'stoker/openapi/schemas';
+
+import { notFoundSchema } from '@/lib/constants';
+import * as param from '@/lib/param';
+import { createRoute, z } from '@hono/zod-openapi';
+
+import { insertSchema, patchSchema, selectSchema } from './utils';
+
+const tags = ['fde.respond_student'];
+
+export const list = createRoute({
+  path: '/fde/respond-student',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.array(selectSchema),
+      'The list of respond students',
+    ),
+  },
+});
+
+export const create = createRoute({
+  path: '/fde/respond-student',
+  method: 'post',
+  request: {
+    body: jsonContentRequired(
+      insertSchema,
+      'The respond student to create',
+    ),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The created respond student',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(insertSchema),
+      'The validation error(s)',
+    ),
+  },
+});
+
+export const getOne = createRoute({
+  path: '/fde/respond-student/{uuid}',
+  method: 'get',
+  request: {
+    params: param.uuid,
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The requested respond student',
+    ),
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'respond student not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(param.uuid),
+      'Invalid id error',
+    ),
+  },
+});
+
+export const patch = createRoute({
+  path: '/fde/respond-student/{uuid}',
+  method: 'patch',
+  request: {
+    params: param.uuid,
+    body: jsonContentRequired(
+      patchSchema,
+      'The respond student to update',
+    ),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The updated respond student',
+    ),
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'respond student not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(patchSchema)
+        .or(createErrorSchema(param.uuid)),
+      'The validation error(s)',
+    ),
+  },
+});
+
+export const remove = createRoute({
+  path: '/fde/respond-student/{uuid}',
+  method: 'delete',
+  request: {
+    params: param.uuid,
+  },
+  tags,
+  responses: {
+    [HSCode.NO_CONTENT]: {
+      description: 'The respond student was deleted successfully',
+    },
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'respond student not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(param.uuid),
+      'Invalid id error',
+    ),
+  },
+});
+
+export type ListRoute = typeof list;
+export type CreateRoute = typeof create;
+export type GetOneRoute = typeof getOne;
+export type PatchRoute = typeof patch;
+export type RemoveRoute = typeof remove;

--- a/src/routes/fde/respond_student/utils.ts
+++ b/src/routes/fde/respond_student/utils.ts
@@ -1,0 +1,35 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+
+import { dateTimePattern } from '@/utils';
+
+import { respond_student } from '../schema';
+
+//* crud
+export const selectSchema = createSelectSchema(respond_student);
+
+export const insertSchema = createInsertSchema(
+  respond_student,
+  {
+    uuid: schema => schema.uuid.length(21),
+    sem_crs_thr_entry_uuid: schema => schema.sem_crs_thr_entry_uuid.length(21),
+    created_by: schema => schema.created_by.length(21),
+    created_at: schema => schema.created_at.regex(dateTimePattern, {
+      message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    updated_at: schema => schema.updated_at.regex(dateTimePattern, {
+      message: 'updated_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+  },
+).required({
+  uuid: true,
+  sem_crs_thr_entry_uuid: true,
+  id: true,
+  evaluation_time: true,
+  created_at: true,
+  created_by: true,
+}).partial({
+  updated_at: true,
+  remarks: true,
+});
+
+export const patchSchema = insertSchema.partial();

--- a/src/routes/fde/schema.ts
+++ b/src/routes/fde/schema.ts
@@ -1,0 +1,135 @@
+import { relations } from 'drizzle-orm';
+import { boolean, integer, pgSchema, text, unique } from 'drizzle-orm/pg-core';
+
+import { DateTime, defaultUUID, PG_DECIMAL, uuid_primary } from '@/lib/variables';
+import { DEFAULT_OPERATION } from '@/utils/db';
+
+import { users } from '../hr/schema';
+import { sem_crs_thr_entry } from '../lib/schema';
+
+const fde = pgSchema('fde');
+
+//* fde *//
+export const qns_category = fde.table('qns_category', {
+  uuid: uuid_primary,
+  index: integer('index').notNull().unique(),
+  name: text('name').notNull(),
+  min_percentage: PG_DECIMAL('min_percentage').notNull(),
+  created_by: defaultUUID('created_by').references(
+    () => users.uuid,
+    DEFAULT_OPERATION,
+  ),
+  created_at: DateTime('created_at').notNull(),
+  updated_at: DateTime('updated_at'),
+  remarks: text('remarks'),
+});
+
+export const qns = fde.table('qns', {
+  uuid: uuid_primary,
+  qns_category_uuid: defaultUUID('qns_category_uuid')
+    .references(() => qns_category.uuid, DEFAULT_OPERATION)
+    .notNull(),
+  index: integer('index').notNull().unique(),
+  name: text('name').notNull(),
+  active: boolean('active').notNull().default(true),
+  created_by: defaultUUID('created_by').references(
+    () => users.uuid,
+    DEFAULT_OPERATION,
+  ),
+  created_at: DateTime('created_at').notNull(),
+  updated_at: DateTime('updated_at'),
+  remarks: text('remarks'),
+});
+
+export const respond_student_evaluation_time = fde.enum('respond_student_evaluation_time', [
+  'mid',
+  'final',
+]);
+
+export const respond_student = fde.table('respond_student', {
+  uuid: uuid_primary,
+  sem_crs_thr_entry_uuid: defaultUUID('sem_crs_thr_entry_uuid')
+    .references(() => sem_crs_thr_entry.uuid, DEFAULT_OPERATION)
+    .notNull(),
+  id: text('id').notNull(),
+  evaluation_time: respond_student_evaluation_time('evaluation_time').notNull(),
+  created_by: defaultUUID('created_by').references(
+    () => users.uuid,
+    DEFAULT_OPERATION,
+  ),
+  created_at: DateTime('created_at').notNull(),
+  updated_at: DateTime('updated_at'),
+  remarks: text('remarks'),
+}, table => [
+  unique('respond_student_sem_crs_thr_entry_uuid_id_evaluation_time_unique').on(
+    table.sem_crs_thr_entry_uuid,
+    table.id,
+    table.evaluation_time,
+  ),
+]);
+
+export const evaluation = fde.table('evaluation', {
+  uuid: uuid_primary,
+  respond_student_uuid: defaultUUID('respond_student_uuid')
+    .references(() => respond_student.uuid, DEFAULT_OPERATION)
+    .notNull(),
+  qns_uuid: defaultUUID('qns_uuid')
+    .references(() => qns.uuid, DEFAULT_OPERATION)
+    .notNull(),
+  rating: integer('rating').notNull(),
+  created_by: defaultUUID('created_by').references(
+    () => users.uuid,
+    DEFAULT_OPERATION,
+  ),
+  created_at: DateTime('created_at').notNull(),
+  updated_at: DateTime('updated_at'),
+  remarks: text('remarks'),
+});
+
+//* relations
+
+export const qns_category_relations = relations(qns_category, ({ one }) => ({
+  created_by: one(users, {
+    fields: [qns_category.created_by],
+    references: [users.uuid],
+  }),
+}));
+
+export const qns_relations = relations(qns, ({ one }) => ({
+  qns_category: one(qns_category, {
+    fields: [qns.qns_category_uuid],
+    references: [qns_category.uuid],
+  }),
+  created_by: one(users, {
+    fields: [qns.created_by],
+    references: [users.uuid],
+  }),
+}));
+
+export const respond_student_relations = relations(respond_student, ({ one }) => ({
+  sem_crs_thr_entry: one(sem_crs_thr_entry, {
+    fields: [respond_student.sem_crs_thr_entry_uuid],
+    references: [sem_crs_thr_entry.uuid],
+  }),
+  created_by: one(users, {
+    fields: [respond_student.created_by],
+    references: [users.uuid],
+  }),
+}));
+
+export const evaluation_relations = relations(evaluation, ({ one }) => ({
+  respond_student: one(respond_student, {
+    fields: [evaluation.respond_student_uuid],
+    references: [respond_student.uuid],
+  }),
+  qns: one(qns, {
+    fields: [evaluation.qns_uuid],
+    references: [qns.uuid],
+  }),
+  created_by: one(users, {
+    fields: [evaluation.created_by],
+    references: [users.uuid],
+  }),
+}));
+
+export default fde;

--- a/src/routes/index.route.ts
+++ b/src/routes/index.route.ts
@@ -1,3 +1,4 @@
+import fde from './fde';
 import hr from './hr';
 import inquire from './inquire';
 import lib from './lib';
@@ -14,6 +15,7 @@ const routes = [
   ...procure,
   ...report,
   ...lib,
+  ...fde,
 ] as const;
 
 export default routes;

--- a/src/routes/index.schema.ts
+++ b/src/routes/index.schema.ts
@@ -1,3 +1,4 @@
+import * as fde from './fde/schema';
 import * as hr from './hr/schema';
 import * as inquire from './inquire/schema';
 import * as lib from './lib/schema';
@@ -10,6 +11,7 @@ const schema = {
   ...inquire,
   ...procure,
   ...lib,
+  ...fde,
 };
 
 export type Schema = typeof schema;


### PR DESCRIPTION
- Introduced evaluation routes including create, list, getOne, patch, and remove functionalities.
- Implemented handlers for evaluation operations with appropriate database interactions.
- Created schemas for validation of evaluation data.
- Added qns and qns_category routes, handlers, and schemas to support evaluation.
- Established relationships in the database schema for evaluations, questions, and responding students.
- Updated index files to include new routes and handlers for fde module.