### PR TITLE
fix: rename 'item_work_order_uuid' to 'uuid' in bill payment details …

### DIFF
--- a/src/routes/procure/bill/handlers.ts
+++ b/src/routes/procure/bill/handlers.ts
@@ -151,7 +151,7 @@ export const getBillAndBillPaymentDetailsByBillUuid: AppRouteHandler<GetBillAndB
      SELECT COALESCE(
         json_agg(
           json_build_object(
-            'item_work_order_uuid', iwo.uuid
+            'uuid', iwo.uuid
           )
         ), '[]'::json
       )


### PR DESCRIPTION
…query